### PR TITLE
Fix: Remove unnecessary (breaking) Composer build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 7.4
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
-
       - uses: actions/setup-node@v3
         with:
           node-version: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,6 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
-      - name: Install composer dependencies
-        uses: php-actions/composer@v5
-        with:
-          php_version: 7.4
-          dev: no
-
       - uses: actions/setup-node@v3
         with:
           node-version: 20


### PR DESCRIPTION
Turns out that this project doesn't use Composer 😅 

This resolves the issue reported in  https://github.com/binarykitchen/videomail-for-ninja-forms/pull/35#issuecomment-1817733324.